### PR TITLE
Fix Accordionverlinkung

### DIFF
--- a/includes/Accordion/assets/js/rrze-accordion.js
+++ b/includes/Accordion/assets/js/rrze-accordion.js
@@ -58,7 +58,7 @@ jQuery(document).ready(function($) {
                 var $target = $('body').find('#' + $findid);
             }
         } else {
-            var $findname = identifier.replace('\#', '');
+            var $findname = window.location.hash.replace('\#', '');
             var $target = $('body').find('div[name=' + $findname + ']');
         }
         if ($target.length > 0) {


### PR DESCRIPTION
Wenn man auf ein Accordion verlinkt hat, dass im name-Attribut einen Unterstrich enthält, dann hat das automatische Öffnen und Scrollen nicht funktioniert.