### PR TITLE
Fix Rahmen und Breite gleichzeitig

### DIFF
--- a/includes/Button/Button.php
+++ b/includes/Button/Button.php
@@ -63,7 +63,7 @@ class Button
         if ($width == 'full') {
             $width_full = ' full-btn';
         } elseif (is_numeric($width)) {
-            $width_px = 'width:' . $width . 'px; max-width:100%;"';
+            $width_px = 'width:' . $width . 'px; max-width:100%;';
         } elseif (strpos($width, 'px')) {
             $width = $width . 'px';
         }


### PR DESCRIPTION
Wenn man Rahmen und Breite gleichzeitig gesetzt hat, wird der Rahmen nicht angezeigt.