### PR TITLE
Update _tabs.scss

### DIFF
--- a/assets/css/_tabs.scss
+++ b/assets/css/_tabs.scss
@@ -89,6 +89,9 @@
         }
     }
 }
+.slick-slide[role=tabpanel] {
+    padding: 0;
+}
 .print-only {
     display: none;
     @media print {


### PR DESCRIPTION
Fix eines Darstellungsproblems beim ILI-Template (Startseite), durch den der Text des "content slider" keinen Abstand zum unteren Rand hat.